### PR TITLE
Add approximation to current SecureDrop theme

### DIFF
--- a/buttons/push_button.css
+++ b/buttons/push_button.css
@@ -1,114 +1,76 @@
 .button {
-	border-radius: 2px;
-	font: 500 14px 'Monsterrat';
-	letter-spacing: 1px;
-	margin: 4px 4px;
-	outline: none;
-	padding: 10px 16px;
+	margin: 0px 0px 0px 12px;
+	height: 40px;
+	margin: 0;
+	padding-left: 20px;
+	padding-right: 20px;
+	border: 2px solid #2a319d;
+	font-family: 'Montserrat';
+	font-weight: 500;
+	font-size: 15px;
+	color: #2a319d;
 }
 
 .contained {
-	background-color: #6200ee;
-	background-color: #283593;
-	border: 1px solid #6200ee;
-	border: 1px solid #283593;
-	color: #ffffff;
+	background-color: #2a319d;
+	color: #fff;
 }
 
 .contained:focus {
-	letter-spacing: 0;
-	background-color: #873df2;
-	border: 1px solid #873df2;
-	color: white;
-	background-color: #283593;
-	border: 1px solid #283593;
-	background-color: rgba(0, 229, 255, 0.96);
-	border: 1px solid rgba(0, 229, 255, 0.96);
-	border: 1px solid #aaaaaa;
-	color: #001064;
+	/* Intentionally left blank. */
 }
 
 .contained:hover {
-	background-color: #6e14ef;
-	border: 1px solid #6e14ef;
-	color: white;
-	background-color: #283593;
-	border: 1px solid #283593;
-	background-color: rgba(0, 229, 255, 0.48);
-	border: 1px solid #aaaaaa;
-	color: #001064;
+	/* Intentionally left blank. */
 }
 
 .contained:pressed {
-	background-color: #9452f3;
-	border: 1px solid #9452f3;
-	color: white;
-	background-color: #283593;
-	border: 1px solid #283593;
-	background-color: rgba(0, 229, 255, 0.32);
-	border: 1px solid #aaaaaa;
-	color: #001064;
+	/* Intentionally left blank. */
 }
 
 .contained:disabled {
-	background-color: #cccccc;
-	border: 1px solid #cccccc;
-	color: #838383;
+	border: 2px solid #c2c4e3;
+	background-color: #c2c4e3;
+	color: #e1e2f1;
 }
 
 .outlined {
-	border: 1px solid #aaaaaa;
-	color: #6200ee;
-	color: #283593;
-	color: #001064;
+	/* Intentionally left blank. */
 }
 
 .outlined:focus {
-	background-color: rgba(98, 0, 238, 0.12);
-	background-color: rgba(0, 229, 255, 0.48);
+	/* Intentionally left blank. */
 }
 
 .outlined:hover {
-	background-color: rgba(98, 0, 238, 0.08);
-	background-color: rgba(0, 229, 255, 0.96);
+	/* Intentionally left blank. */
 }
 
 .outlined:pressed {
-	background-color: rgba(98, 0, 238, 0.24);
-	background-color: rgba(0, 229, 255, 0.32);
+	/* Intentionally left blank. */
 }
 
 .outlined:disabled {
-	border: 1px solid #cccccc;
-	color: #838383;
+	border: 2px solid rgba(42, 49, 157, 0.4);
+	color: rgba(42, 49, 157, 0.4);
 }
 
 .text {
-	border: 1px solid transparent;
-	color: #6200ee;
-	color: #283593;
-	color: #001064;
+	/* Intentionally left blank. */
 }
 
 .text:focus {
-	background-color: rgba(98, 0, 238, 0.12);
-	background-color: rgba(0, 229, 255, 0.48);
-	color: black;
+	/* Intentionally left blank. */
 }
 
 .text:hover {
-	background-color: rgba(98, 0, 238, 0.08);
-	background-color: rgba(0, 229, 255, 0.08);
-	background-color: rgba(0, 229, 255, 0.96);
-	color: black;
+	/* Intentionally left blank. */
 }
 
 .text:pressed {
-	background-color: rgba(98, 0, 238, 0.24);
-	background-color: rgba(0, 178, 204, 0.32);
-	color: black;
+	/* Intentionally left blank. */
 }
 
 .text:disabled {
-	color: #838383;
+	/* Intentionally left blank. */
 }

--- a/buttons/push_button.css
+++ b/buttons/push_button.css
@@ -1,15 +1,17 @@
 .button {
-	border-radius: 4px;
+	border-radius: 2px;
 	font: 500 14px 'Monsterrat';
 	letter-spacing: 1px;
-	margin: 16px 4px;
+	margin: 4px 4px;
 	outline: none;
 	padding: 10px 16px;
 }
 
 .contained {
 	background-color: #6200ee;
+	background-color: #283593;
 	border: 1px solid #6200ee;
+	border: 1px solid #283593;
 	color: #ffffff;
 }
 
@@ -18,18 +20,34 @@
 	background-color: #873df2;
 	border: 1px solid #873df2;
 	color: white;
+	background-color: #283593;
+	border: 1px solid #283593;
+	background-color: rgba(0, 229, 255, 0.96);
+	border: 1px solid rgba(0, 229, 255, 0.96);
+	border: 1px solid #aaaaaa;
+	color: #001064;
 }
 
 .contained:hover {
 	background-color: #6e14ef;
 	border: 1px solid #6e14ef;
 	color: white;
+	background-color: #283593;
+	border: 1px solid #283593;
+	background-color: rgba(0, 229, 255, 0.48);
+	border: 1px solid #aaaaaa;
+	color: #001064;
 }
 
 .contained:pressed {
 	background-color: #9452f3;
 	border: 1px solid #9452f3;
 	color: white;
+	background-color: #283593;
+	border: 1px solid #283593;
+	background-color: rgba(0, 229, 255, 0.32);
+	border: 1px solid #aaaaaa;
+	color: #001064;
 }
 
 .contained:disabled {
@@ -41,18 +59,23 @@
 .outlined {
 	border: 1px solid #aaaaaa;
 	color: #6200ee;
+	color: #283593;
+	color: #001064;
 }
 
 .outlined:focus {
 	background-color: rgba(98, 0, 238, 0.12);
+	background-color: rgba(0, 229, 255, 0.48);
 }
 
 .outlined:hover {
 	background-color: rgba(98, 0, 238, 0.08);
+	background-color: rgba(0, 229, 255, 0.96);
 }
 
 .outlined:pressed {
 	background-color: rgba(98, 0, 238, 0.24);
+	background-color: rgba(0, 229, 255, 0.32);
 }
 
 .outlined:disabled {
@@ -63,18 +86,27 @@
 .text {
 	border: 1px solid transparent;
 	color: #6200ee;
+	color: #283593;
+	color: #001064;
 }
 
 .text:focus {
 	background-color: rgba(98, 0, 238, 0.12);
+	background-color: rgba(0, 229, 255, 0.48);
+	color: black;
 }
 
 .text:hover {
 	background-color: rgba(98, 0, 238, 0.08);
+	background-color: rgba(0, 229, 255, 0.08);
+	background-color: rgba(0, 229, 255, 0.96);
+	color: black;
 }
 
 .text:pressed {
 	background-color: rgba(98, 0, 238, 0.24);
+	background-color: rgba(0, 178, 204, 0.32);
+	color: black;
 }
 
 .text:disabled {

--- a/buttons/push_button.py
+++ b/buttons/push_button.py
@@ -154,7 +154,7 @@ class PushButton(QPushButton):
     # https://material.io/design/environment/elevation.html#default-elevations
     Elevation = NewType("Elevation", int)
     ElevationNone = Elevation(0)
-    ElevationLow = Elevation(2)
+    ElevationLow = Elevation(3)
     ElevationMedium = Elevation(4)
     ElevationHigh = Elevation(8)
 
@@ -265,8 +265,9 @@ class PushButton(QPushButton):
         that are provided by this class.
         """
         shadow = QGraphicsDropShadowEffect(self)
-        shadow.setOffset(0, 1*value)
+        shadow.setOffset(0, 0.7*value)
         shadow.setBlurRadius(3*value)
         shadow.setColor(QColor("#44000000"))
+        shadow.setColor(QColor("#0000e5ff"))
         self.setGraphicsEffect(shadow)
         self.update()

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 
 from buttons import PushButton
-from wizard import Wizard
+from wizard import ThemedWizard as Wizard
 from device import Device, Simulator as DeviceSimulator
 import export
 

--- a/wizard/__init__.py
+++ b/wizard/__init__.py
@@ -1,1 +1,2 @@
 from .main import Wizard
+from .themed import ThemedWizard

--- a/wizard/main.py
+++ b/wizard/main.py
@@ -1,3 +1,4 @@
+import os
 from enum import IntEnum
 
 from PyQt5.QtCore import *
@@ -40,6 +41,10 @@ class Wizard(QWizard):
 
         for page in [self.page(id) for id in self.pageIds()]:
             page.completeChanged.connect(lambda: self._set_focus(QWizard.WizardButton.NextButton))
+
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, "wizard.css"), "r") as stylesheet:
+            self.setStyleSheet(stylesheet.read())
 
     @pyqtSlot(int)
     def _set_focus(self, which: QWizard.WizardButton) -> None:

--- a/wizard/pages/export_page.py
+++ b/wizard/pages/export_page.py
@@ -1,3 +1,5 @@
+import os
+
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -46,6 +48,10 @@ class ExportPage(QWizardPage):
 
         self._content = content
         self._progress = progress
+
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, "page.css"), "r") as stylesheet:
+            self.setStyleSheet(stylesheet.read())
 
     def isComplete(self) -> bool:
         return self._is_complete

--- a/wizard/pages/insert_device_page.py
+++ b/wizard/pages/insert_device_page.py
@@ -1,3 +1,5 @@
+import os
+
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -23,9 +25,15 @@ class InsertDevicePage(QWizardPage):
         self.setLayout(layout)
 
         device_state_changed.connect(self.completeChanged)
+        self.completeChanged.connect(self._on_complete_changed)
 
         self.instructions = instructions
         self.completion_message = completion_message
+
+    def _on_complete_changed(self) -> None:
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, "page.css"), "r") as stylesheet:
+            self.setStyleSheet(stylesheet.read())
 
     def isComplete(self) -> bool:
         device_state = self.wizard()._device.state

--- a/wizard/pages/page.css
+++ b/wizard/pages/page.css
@@ -1,0 +1,1 @@
+font-size: 16px;

--- a/wizard/pages/review_data_page.py
+++ b/wizard/pages/review_data_page.py
@@ -1,3 +1,5 @@
+import os
+
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -16,3 +18,7 @@ class ReviewDataPage(QWizardPage):
         layout = QVBoxLayout()
         layout.addWidget(content)
         self.setLayout(layout)
+
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, "page.css"), "r") as stylesheet:
+            self.setStyleSheet(stylesheet.read())

--- a/wizard/pages/start_page.py
+++ b/wizard/pages/start_page.py
@@ -1,3 +1,5 @@
+import os
+
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -16,3 +18,7 @@ class StartPage(QWizardPage):
         layout = QVBoxLayout()
         layout.addWidget(content)
         self.setLayout(layout)
+
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, "page.css"), "r") as stylesheet:
+            self.setStyleSheet(stylesheet.read())

--- a/wizard/pages/unlock_device_page.py
+++ b/wizard/pages/unlock_device_page.py
@@ -1,3 +1,5 @@
+import os
+
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -80,6 +82,10 @@ class UnlockDevicePage(QWizardPage):
         self.completion_message = completion_message
         self.unlocking_message = unlocking_message
         self.failure_message = failure_message
+
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, "page.css"), "r") as stylesheet:
+            self.setStyleSheet(stylesheet.read())
 
     def isComplete(self) -> bool:
         return self._device.state == Device.UnlockedState

--- a/wizard/themed.py
+++ b/wizard/themed.py
@@ -1,0 +1,39 @@
+from PyQt5.QtWidgets import QWidget
+
+import export
+from device import Device
+from buttons import PushButton
+
+from .main import Wizard
+
+class ThemedWizard(Wizard):
+
+    def __init__(self, device: Device, export_service: export.Service, parent: QWidget =None):
+        super().__init__(device, export_service, parent)
+
+        self.setOption(Wizard.CancelButtonOnLeft)
+
+        button = PushButton(PushButton.TypeContained)
+        button.setText("Next")
+        self.setButton(Wizard.WizardButton.NextButton, button)
+
+        button = PushButton(PushButton.TypeOutlined)
+        button.setText("Back")
+        self.setButton(Wizard.WizardButton.BackButton, button)
+
+        button = PushButton(PushButton.TypeText)
+        button.setText("Cancel")
+        self.setButton(Wizard.WizardButton.CancelButton, button)
+
+        button = PushButton(PushButton.TypeContained)
+        button.setText("Finish")
+        self.setButton(Wizard.WizardButton.FinishButton, button)
+
+        self.setButtonLayout([
+            Wizard.WizardButton.CancelButton,
+            Wizard.WizardButton.Stretch,
+            Wizard.WizardButton.BackButton,
+            Wizard.WizardButton.NextButton,
+            Wizard.WizardButton.FinishButton,
+        ])
+

--- a/wizard/themed.py
+++ b/wizard/themed.py
@@ -14,19 +14,19 @@ class ThemedWizard(Wizard):
         self.setOption(Wizard.CancelButtonOnLeft)
 
         button = PushButton(PushButton.TypeContained)
-        button.setText("Next")
+        button.setText("CONTINUE")
         self.setButton(Wizard.WizardButton.NextButton, button)
 
         button = PushButton(PushButton.TypeOutlined)
-        button.setText("Back")
+        button.setText("BACK")
         self.setButton(Wizard.WizardButton.BackButton, button)
 
         button = PushButton(PushButton.TypeText)
-        button.setText("Cancel")
+        button.setText("CANCEL")
         self.setButton(Wizard.WizardButton.CancelButton, button)
 
         button = PushButton(PushButton.TypeContained)
-        button.setText("Finish")
+        button.setText("FINISH")
         self.setButton(Wizard.WizardButton.FinishButton, button)
 
         self.setButtonLayout([

--- a/wizard/wizard.css
+++ b/wizard/wizard.css
@@ -1,0 +1,4 @@
+background-color: #ffffff;
+color: #302aa3;
+font-family: 'Montserrat';
+font-size: 24px;


### PR DESCRIPTION
This PR is an exploration into the theming capabilities of the `QWizard` class.

I don't find it easy to work with... internal elements are not easy to identify for targeting, and some QSS properties behave unexpectedly. 

<details><summary>Example of unexpected stylesheet behavior</summary>
>p>For example, when setting margins, a background color, and a border at the top level of the wizard, the background (red in the image below) extends beyond the borders (yellow in the image below). The `#AAA` element is the `QWizard` in this example. :slightly_frowning_face:</p>

<img width="80%" src="https://user-images.githubusercontent.com/1619067/199172823-db0b6efb-056b-4cb2-8192-4e7d0ba8909e.png" alt="A screenshot showing a background color that extends beyond the borders of a widget."/>
</details>

Anyhow, this is the result of a time-boxed exercise.

<img width="40%" src="https://user-images.githubusercontent.com/1619067/199172813-a9d2fd8e-65d9-4ae4-94b2-cb56d0ae3815.png" alt="Screenshot of a SecureDrop-themed wizard, showing enabled buttons." />
<img width="40%" src="https://user-images.githubusercontent.com/1619067/199172819-e21d05eb-ed4c-4863-81dc-e736ec24a012.png" alt="Screenshot of a SecureDrop-themed wizard, showing a disabled button and some form fields." />
